### PR TITLE
Remove misbehaved _verify_redis_connection

### DIFF
--- a/lib/CHI/Driver/Redis/t/CHIDriverTests.pm
+++ b/lib/CHI/Driver/Redis/t/CHIDriverTests.pm
@@ -28,7 +28,6 @@ sub clear_redis : Test(setup) {
     my ($self) = @_;
 
     my $cache = $self->new_cache;
-    $cache->_verify_redis_connection;
     $cache->redis->flushall;
 }
 


### PR DESCRIPTION
This pull-request removes `_verify_redis_connection` which places the burden of error detection and reconnection on the CHI user. That seems appropriate, to me.

The primary bug, is the return statement on [line 165](https://github.com/rentrak/chi-driver-redis/blob/master/lib/CHI/Driver/Redis.pm#L165). That doesn't return from `_verify_redis_connection`, it just returns from the try block. So, even if pinging the server succeeds, a new Redis object is created in the next try block.

In the best case, this creates a new connection for every request. In the worst case, it creates a new connection on the WRONG server. (E.g., you have a Redis server running on localhost, but you initialized with a remote Redis server passing in a fully constructed Redis object, rather than passning in a `server` parameter.)

In our case, we did not have a Redis server on localhost. So, every attempt to access Redis via this CHI driver resulted in a failed attempt to create a new connection, which was discarded, and the operation proceeded using the existing Redis object. (Since the connection attempt failed, the `redis` attribute did not get replaced.

Best practice may be to pass a fully constructed Redis object with auto-reconnect enabled to CHI. (See the [Redis pod](https://metacpan.org/pod/Redis).)

Even if `_verify_redis_connection` did not misbehave by creating (or attempting to create) a new connection on every call, it seems inefficient to ping the server on every call. So, I removed it entirely.

