### PR TITLE
Redis options

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -12,7 +12,6 @@ build_requires 'Test::Class';
 build_requires 'Test::More';
 build_requires 'Test::Mock::Redis';
 
-requires 'Check::ISA';
 requires 'CHI' => '0.36';
 requires 'Moo';
 requires 'Redis' => '1.901';

--- a/lib/CHI/Driver/Redis.pm
+++ b/lib/CHI/Driver/Redis.pm
@@ -196,7 +196,11 @@ to undef to disable automatic encoding.
 
 =head1 CONSTRUCTOR OPTIONS
 
-C<server>, C<debug>, and C<password> are passed to C<Redis>.
+C<redis> option for constructed C<Redis> object.
+
+C<redis_options> for hash of optios to C<Redis> constructor
+
+Other options, including C<server>, C<debug>, and C<password> are passed to C<Redis> constructor.
 
 =head1 ATTRIBUTES
 

--- a/lib/CHI/Driver/Redis.pm
+++ b/lib/CHI/Driver/Redis.pm
@@ -1,7 +1,6 @@
 package CHI::Driver::Redis;
 
 use Moo;
-use Check::ISA;
 use Redis;
 use URI::Escape qw(uri_escape uri_unescape);
 

--- a/lib/CHI/Driver/Redis/t/CHIDriverTests.pm
+++ b/lib/CHI/Driver/Redis/t/CHIDriverTests.pm
@@ -31,4 +31,22 @@ sub clear_redis : Test(setup) {
     $cache->redis->flushall;
 }
 
+sub test_redis_object : Tests(1) {
+    my $self  = shift;
+    my $cache = $self->new_cache(redis => Test::Mock::Redis->new());
+    $cache->clear();
+}
+
+sub test_redis_options : Tests(1) {
+    my $self  = shift;
+    my $cache = $self->new_cache(redis_options => { reconnect => 2 });
+    $cache->clear();
+}
+
+sub test_extra_options : Tests(1) {
+    my $self  = shift;
+    my $cache = $self->new_cache(reconnect => 2);
+    $cache->clear();
+}
+
 1;


### PR DESCRIPTION
Support "redis" option for Redis object.
Support "redis_options" for hash of parameters to Redis constructor.
Pass rest of options to Redis constructor.
