### PR TITLE
change key listing strategy to use SCAN

### DIFF
--- a/lib/CHI/Driver/Redis.pm
+++ b/lib/CHI/Driver/Redis.pm
@@ -110,13 +110,14 @@ sub get_keys {
 sub _get_keys {
     my ($self) = @_;
 
-    my $cursor = "0";
+    my $cursor = undef;
     my @keys;
-    do {
+    while(!defined($cursor) || $cursor ne "0") {
+        $cursor //= "0";
         my @result = $self->redis->scan($cursor, 'match', $self->key_prefix.'*');
         $cursor = shift(@result);
         push @keys, @{shift(@result)};
-    } while($cursor ne "0");
+    } 
 
     # SCAN can return duplicate keys
     return uniq(@keys);

--- a/lib/CHI/Driver/Redis.pm
+++ b/lib/CHI/Driver/Redis.pm
@@ -3,6 +3,7 @@ package CHI::Driver::Redis;
 use Moo;
 use Redis;
 use URI::Escape qw(uri_escape uri_unescape);
+use List::MoreUtils qw(uniq);
 
 extends 'CHI::Driver';
 
@@ -117,7 +118,8 @@ sub _get_keys {
         push @keys, @{shift(@result)};
     } while($cursor ne "0");
 
-    return @keys;
+    # SCAN can return duplicate keys
+    return uniq(@keys);
 }
 
 sub get_namespaces {

--- a/lib/CHI/Driver/Redis.pm
+++ b/lib/CHI/Driver/Redis.pm
@@ -133,8 +133,6 @@ sub remove {
 
     return unless defined($key);
 
-    my $ns = $self->prefix . $self->namespace;
-
     my $skey = uri_escape($key);
 
     $self->redis->del($self->key_prefix . $skey);
@@ -143,10 +141,9 @@ sub remove {
 sub store {
     my ($self, $key, $data, $expires_in) = @_;
 
-    my $ns = $self->prefix . $self->namespace;
 
     my $skey = uri_escape($key);
-    my $realkey = $ns . '||' . $skey;
+    my $realkey = $self->key_prefix . $skey;
 
     $self->redis->sadd($self->prefix . 'chinamespaces', $self->namespace);
     $self->redis->set($realkey, $data);

--- a/lib/CHI/Driver/Redis/t/CHIDriverTests.pm
+++ b/lib/CHI/Driver/Redis/t/CHIDriverTests.pm
@@ -33,7 +33,7 @@ sub clear_redis : Test(setup) {
 
 sub test_redis_object : Tests(1) {
     my $self  = shift;
-    my $cache = $self->new_cache(redis => Test::Mock::Redis->new());
+    my $cache = $self->new_cache();
     $cache->clear();
 }
 


### PR DESCRIPTION
This fixed the key listing set leak that occurs when keys are expiring as described in : 
https://rt.cpan.org/Public/Bug/Display.html?id=112760

This instead uses the SCAN method of Redis to list the keys.

This has the downside of requiring redis 2.8+ and being slower than the previous implementation.
Also, Test::Mock::Redis doesn't implement the SCAN method so unit tests will only succeed when testing against a real Redis instance
